### PR TITLE
docs: разметка md-файла модулей

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -117,7 +117,6 @@ def handler():
 
 ## URL маршруты
 URL-пути также добавляются автоматически функцией `discover_installed_app_urls` из `api/src/config/auto_config.py`. Функция находит все файлы `urls.py` в `api/src/external` и добавляет их маршруты в общую конфигурацию URL.
-```
 
 # Пример структуры LMS модуля
 


### PR DESCRIPTION
В разметке файла документации были лишние управляющие символы
![image](https://github.com/user-attachments/assets/15c3a4ee-b31a-4adf-9d54-be89f1e569e0)
Были убраны лишние символы
![image](https://github.com/user-attachments/assets/d21de0ef-af86-4baa-ac40-2d926a2fe242)
