### PR TITLE
fix: Исправить ошибку в пути при создании файла в команде создания подмодуля

### DIFF
--- a/src/core/utils/management/commands/add_submodule.py
+++ b/src/core/utils/management/commands/add_submodule.py
@@ -137,7 +137,7 @@ class Command(BaseCommand):
 
                     # Создавайте свои представления здесь
                 """),
-                'migrations\__init__.py': '',
+                os.path.join('migrations', '__init__.py'): '',
             }
 
             self.create_file_structure(submodule_directory, files_to_create)


### PR DESCRIPTION
При создании файла __init__.py в папке migrations в команде создании подмодуля указывается путь с обратным слешем, из-за чего на Линуксе файл создаётся в корневой директории подмодуля. Ошибка исправляется с помощью использования функции os.path.join.