### PR TITLE
fix: Решение проблемы с регулярным выражением при миграции

### DIFF
--- a/src/core/cms/views.py
+++ b/src/core/cms/views.py
@@ -1308,7 +1308,7 @@ class PatchAllProgectPages(BaseAPIViewAuthMixin):
                     route_constants = [const for const in route_constants if (const != 'mainRoutes')& (const!= 'adminpanelRoutes')
                         & (const!= 'userRoutes') & (const!='settingsRoutes') &(const!= 'startRoutes')]
                     for const_name in route_constants:
-                        const_pattern = f"const {const_name} = \[(.*?)\]"
+                        const_pattern = rf"const {const_name} = \[(.*?)\]"
                         const_match = re.search(const_pattern, content, re.DOTALL)
                         content_const = const_match.group(1)
                         const_pattern = f"path: '(.*?)'"


### PR DESCRIPTION
`\src\core\cms\views.py:1311: SyntaxWarning: invalid escape sequence '\['
  const_pattern = f"const {const_name} = \[(.*?)\]"
m version 1.6.1 when using version 1.7.0. This might lead to breaking code or invalid results. Use at your own risk.`